### PR TITLE
Clean up cmake files to take ICU from system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+*.a
+*.dylib

--- a/integration_tests/ctesque/src/test/java/android/database/SQLiteDatabaseTest.java
+++ b/integration_tests/ctesque/src/test/java/android/database/SQLiteDatabaseTest.java
@@ -18,10 +18,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.internal.DoNotInstrument;
+import org.robolectric.annotation.SQLiteMode;
 
 /** Compatibility test for {@link android.database.sqlite.SQLiteDatabase} */
 @DoNotInstrument
 @RunWith(AndroidJUnit4.class)
+@SQLiteMode(SQLiteMode.Mode.NATIVE)
 public class SQLiteDatabaseTest {
 
   private SQLiteDatabase database;

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -4,6 +4,26 @@ import org.robolectric.gradle.RoboJavaModulePlugin
 apply plugin: RoboJavaModulePlugin
 apply plugin: DeployedRoboJavaModulePlugin
 
+static def osName() {
+  def osName = System.getProperty("os.name").toLowerCase(Locale.US);
+  if (osName.contains("linux")) {
+    return "linux"
+  } else if (osName.contains("mac")) {
+    return "mac"
+  } else if (osName.contains("win")) {
+    return "windows"
+  }
+  return "unknown"
+}
+
+static def arch() {
+  def arch = System.getProperty("os.arch").toLowerCase(Locale.US);
+  if (arch.equals("x86_64") || arch.equals("amd64")) {
+    return "x86_64"
+  }
+  return arch
+}
+
 task cmakeNativeRuntime(type:Exec) {
   workingDir "$buildDir/cpp"
   commandLine 'cmake', "$projectDir/cpp/"
@@ -21,16 +41,21 @@ task makeNativeRuntime(type:Exec) {
 task copyNativeRuntime(type: Copy) {
   dependsOn makeNativeRuntime
   from ("$buildDir/cpp") {
-    include 'libnativeruntime.so'
+    include '*libnativeruntime.*'
   }
   rename { String fileName ->
-    fileName.replace("libnativeruntime", "robolectric-nativeruntime")
+    fileName.replace("libnativeruntime", "librobolectric-nativeruntime")
   }
-  into project.file("$buildDir/resources/main/native/linux/64/")
+  into project.file("$buildDir/resources/main/native/${osName()}/${arch()}/")
 }
 
 jar {
-  dependsOn copyNativeRuntime
+  def os = osName()
+  if (os.contains("linux") || os.contains("mac")) {
+    dependsOn copyNativeRuntime
+  } else {
+    println("Skipping the nativeruntime build for OS " + System.getProperty("os.name"))
+  }
 }
 
 dependencies {

--- a/nativeruntime/build.gradle
+++ b/nativeruntime/build.gradle
@@ -25,8 +25,7 @@ static def arch() {
 }
 
 task cmakeNativeRuntime(type:Exec) {
-  workingDir "$buildDir/cpp"
-  commandLine 'cmake', "$projectDir/cpp/"
+  commandLine 'cmake', "-S", "$projectDir/cpp/", "-B", "$buildDir/cpp"
   doFirst {
     mkdir "$buildDir/cpp"
   }

--- a/nativeruntime/cpp/CMakeLists.txt
+++ b/nativeruntime/cpp/CMakeLists.txt
@@ -40,10 +40,7 @@ set(SQLITE_COMPILE_OPTIONS
 
 include_directories(${ANDROID_SQLITE_DIR}/dist)
 include_directories(${ANDROID_SQLITE_DIR}/android)
-
-#if(APPLE)
-#    include_directories(/opt/homebrew/opt/icu4c/include)
-#endif()
+include_directories(${ICU_INCLUDE_DIRS})
 
 add_library(androidsqlite STATIC
   ${ANDROID_SQLITE_DIR}/android/OldPhoneNumberUtils.cpp
@@ -57,11 +54,8 @@ add_library(androidsqlite STATIC
 target_compile_options(androidsqlite PRIVATE ${SQLITE_COMPILE_OPTIONS})
 
 target_link_libraries(androidsqlite
-    /opt/homebrew/opt/icu4c/lib/libicuuc.a
-    /opt/homebrew/opt/icu4c/lib/libicui18n.a
-    /opt/homebrew/opt/icu4c/lib/libicudata.a
-#  ICU::uc
-#  ICU::i18n
+  ICU::uc
+  ICU::i18n
 )
 
 include_directories(${JNI_INCLUDE_DIRS})
@@ -82,8 +76,6 @@ include_directories(libcutils/include)
 
 include_directories(base/include)
 
-include_directories(${ICU_INCLUDE_DIRS})
-
 add_library(nativeruntime SHARED
   jni/AndroidRuntime.cpp
   jni/AndroidRuntime.h
@@ -94,16 +86,12 @@ add_library(nativeruntime SHARED
   jni/robo_android_database_SQLiteConnection.cpp
 )
 
-# if(APPLE)
-#  link_directories(nativeruntime /opt/homebrew/opt/icu4c/lib)
-# endif()
-
 target_link_libraries(nativeruntime
-  # -static-libgcc
-  -static-libstdc++
   log
   utils
   androidsqlite
   cutils
   androidfw
+  ICU::uc
+  ICU::i18n
 )

--- a/nativeruntime/cpp/CMakeLists.txt
+++ b/nativeruntime/cpp/CMakeLists.txt
@@ -6,6 +6,7 @@ project(nativeruntime)
 set (CMAKE_CXX_STANDARD 17)
 
 find_package(JNI REQUIRED)
+find_package(ICU COMPONENTS uc i18n REQUIRED)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -40,6 +41,10 @@ set(SQLITE_COMPILE_OPTIONS
 include_directories(${ANDROID_SQLITE_DIR}/dist)
 include_directories(${ANDROID_SQLITE_DIR}/android)
 
+#if(APPLE)
+#    include_directories(/opt/homebrew/opt/icu4c/include)
+#endif()
+
 add_library(androidsqlite STATIC
   ${ANDROID_SQLITE_DIR}/android/OldPhoneNumberUtils.cpp
   ${ANDROID_SQLITE_DIR}/android/PhoneNumberUtils.cpp
@@ -50,6 +55,14 @@ add_library(androidsqlite STATIC
 )
 
 target_compile_options(androidsqlite PRIVATE ${SQLITE_COMPILE_OPTIONS})
+
+target_link_libraries(androidsqlite
+    /opt/homebrew/opt/icu4c/lib/libicuuc.a
+    /opt/homebrew/opt/icu4c/lib/libicui18n.a
+    /opt/homebrew/opt/icu4c/lib/libicudata.a
+#  ICU::uc
+#  ICU::i18n
+)
 
 include_directories(${JNI_INCLUDE_DIRS})
 
@@ -69,6 +82,8 @@ include_directories(libcutils/include)
 
 include_directories(base/include)
 
+include_directories(${ICU_INCLUDE_DIRS})
+
 add_library(nativeruntime SHARED
   jni/AndroidRuntime.cpp
   jni/AndroidRuntime.h
@@ -79,8 +94,12 @@ add_library(nativeruntime SHARED
   jni/robo_android_database_SQLiteConnection.cpp
 )
 
+# if(APPLE)
+#  link_directories(nativeruntime /opt/homebrew/opt/icu4c/lib)
+# endif()
+
 target_link_libraries(nativeruntime
-  -static-libgcc
+  # -static-libgcc
   -static-libstdc++
   log
   utils

--- a/nativeruntime/cpp/libcutils/ashmem.cpp
+++ b/nativeruntime/cpp/libcutils/ashmem.cpp
@@ -67,10 +67,10 @@ int ashmem_create_region(const char* /*ignored*/, size_t size) {
 
   unlink(pattern);
 
-  if (TEMP_FAILURE_RETRY(ftruncate(fd, size)) == -1) {
-    close(fd);
-    return -1;
-  }
+  long int result = 0;
+  do {
+    result = ftruncate(fd, size);
+  } while (result == -1L && errno == EINTR);
 
   return fd;
 }

--- a/nativeruntime/cpp/liblog/log.c
+++ b/nativeruntime/cpp/liblog/log.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdarg.h>
 
 int __android_log_print(int prio, const char* tag, const char* fmt, ...) {
   ((void)prio);

--- a/nativeruntime/src/main/java/org/robolectric/nativeruntime/NativeRuntimeLoader.java
+++ b/nativeruntime/src/main/java/org/robolectric/nativeruntime/NativeRuntimeLoader.java
@@ -6,13 +6,18 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Locale;
 
 /** Loads the Roboelctric native runtime. */
 public final class NativeRuntimeLoader {
   private static final AtomicBoolean loaded = new AtomicBoolean(false);
 
   static {
-    ensureLoaded();
+    if (isSupported()) {
+      ensureLoaded();
+    } else {
+      throw new AssertionError("The Robolectric native runtime is not supported in this OS/Architecture");
+    }
   }
 
   private NativeRuntimeLoader() {}
@@ -20,15 +25,45 @@ public final class NativeRuntimeLoader {
   static void ensureLoaded() {
     if (loaded.compareAndSet(false, true)) {
       try {
+        String libraryName = System.mapLibraryName("robolectric-nativeruntime");
+        System.out.println("DSP Library name = " + libraryName);
         File tmpLibraryFile =
-            java.nio.file.Files.createTempFile("", "robolectric-nativeruntime.so").toFile();
+            java.nio.file.Files.createTempFile("", libraryName).toFile();
         tmpLibraryFile.deleteOnExit();
-        URL resource = Resources.getResource("native/linux/64/robolectric-nativeruntime.so");
+        URL resource = Resources.getResource(nativeLibraryPath());
         Resources.asByteSource(resource).copyTo(Files.asByteSink(tmpLibraryFile));
         System.load(tmpLibraryFile.getAbsolutePath());
       } catch (IOException e) {
         throw new AssertionError("Unable to load Robolectric nativeruntime library", e);
       }
     }
+  }
+
+  private static boolean isSupported() {
+    return  ("mac".equals(osName()) && "aarch64".equals(arch()) || ("linux".equals(osName()) && "x86_64".equals(arch())));
+  }
+
+  private static String nativeLibraryPath() {
+    return String.format("native/%s/%s/%s", osName(), arch(), System.mapLibraryName("robolectric-nativeruntime"));
+  }
+
+  private static String osName() {
+    String osName = System.getProperty("os.name").toLowerCase(Locale.US);
+    if (osName.contains("linux")) {
+      return "linux";
+    } else if (osName.contains("mac")) {
+      return "mac";
+    }
+    return "unsupported";
+  }
+
+  private static String arch() {
+    String arch = System.getProperty("os.arch").toLowerCase(Locale.US);
+    if (arch.equals("x86_64") || arch.equals("amd64")) {
+      return "x86_84";
+    } else if (arch.equals("aarch64")) {
+      return "aarch64";
+    }
+    return "unsupported";
   }
 }

--- a/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
+++ b/robolectric/src/test/java/org/robolectric/shadows/SQLiteDatabaseTest.java
@@ -22,7 +22,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.SQLiteMode;
 
+@SQLiteMode(SQLiteMode.Mode.NATIVE)
 @RunWith(AndroidJUnit4.class)
 public class SQLiteDatabaseTest {
   private SQLiteDatabase database;

--- a/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
+++ b/shadows/framework/src/main/java/org/robolectric/shadows/util/SQLiteLibraryLoader.java
@@ -113,6 +113,8 @@ public class SQLiteLibraryLoader {
     if (name.contains("win")) {
       return OS_WIN;
     } else if (name.contains("linux")) {
+
+
       return OS_LINUX;
     } else if (name.contains("mac")) {
       return OS_MAC;


### PR DESCRIPTION
- if this does not work on Mac, try setting the env variable where to
  find ICU lib first
  - if installed via homebrew, set this:
    export ICU_ROOT=/opt/homebrew/opt/icu4c
- also, this will tell cmake to use the out-of-source build directory
  when called via `./gradlew clean assemble`